### PR TITLE
Angular 6+ compatibility

### DIFF
--- a/lib/modes/CircleMode.js
+++ b/lib/modes/CircleMode.js
@@ -1,4 +1,4 @@
-const MapboxDraw = require('@mapbox/mapbox-gl-draw');
+const MapboxDraw = require('@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw');
 const Constants = require('@mapbox/mapbox-gl-draw/src/constants');
 const doubleClickZoom = require('@mapbox/mapbox-gl-draw/src/lib/double_click_zoom');
 const circle = require('@turf/circle').default;

--- a/lib/modes/DirectModeOverride.js
+++ b/lib/modes/DirectModeOverride.js
@@ -1,4 +1,4 @@
-const MapboxDraw = require('@mapbox/mapbox-gl-draw');
+const MapboxDraw = require('@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw');
 const createSupplementaryPoints = require('@mapbox/mapbox-gl-draw/src/lib/create_supplementary_points');
 const moveFeatures = require('@mapbox/mapbox-gl-draw/src/lib/move_features');
 const Constants = require('@mapbox/mapbox-gl-draw/src/constants');

--- a/lib/modes/DragCircleMode.js
+++ b/lib/modes/DragCircleMode.js
@@ -1,4 +1,4 @@
-const MapboxDraw = require('@mapbox/mapbox-gl-draw');
+const MapboxDraw = require('@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw');
 const Constants = require('@mapbox/mapbox-gl-draw/src/constants');
 const doubleClickZoom = require('@mapbox/mapbox-gl-draw/src/lib/double_click_zoom');
 const dragPan = require('../utils/drag_pan');

--- a/lib/modes/SimpleSelectModeOverride.js
+++ b/lib/modes/SimpleSelectModeOverride.js
@@ -1,4 +1,4 @@
-const MapboxDraw = require('@mapbox/mapbox-gl-draw');
+const MapboxDraw = require('@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw');
 const createSupplementaryPoints = require('@mapbox/mapbox-gl-draw/src/lib/create_supplementary_points');
 const moveFeatures = require('@mapbox/mapbox-gl-draw/src/lib/move_features');
 const Constants = require('@mapbox/mapbox-gl-draw/src/constants');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Anvesh Kumar Arrabochu",
   "license": "MIT",
   "dependencies": {
-    "@mapbox/mapbox-gl-draw": "1.1.1",
+    "@mapbox/mapbox-gl-draw": "1.3.0",
     "@turf/along": "^6.0.1",
     "@turf/circle": "^6.0.1",
     "@turf/distance": "^6.0.1",


### PR DESCRIPTION
Fixes the issue described here: https://github.com/mapbox/mapbox-gl-draw/issues/850

Allows for compatibility with angular 6+ by changing the way mapbox-gl-draw is imported. I'm not sure if this is the best way to fix this but it seems to be the only way to get it working.