### PR TITLE
add onMouseMove function

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Sample feature object returned in `draw.create` event
 
 ## Changelog
 
+### v1.1.2
+
+* 开启定制化维护
+* 增加鼠标移出地图时执行绘制完成操作
+
 ### v1.1.0
 
 * Added a new DragCircle mode.

--- a/lib/modes/DragCircleMode.js
+++ b/lib/modes/DragCircleMode.js
@@ -58,7 +58,7 @@ DragCircleMode.onDrag = DragCircleMode.onMouseMove = function (state, e) {
   }
 };
 
-DragCircleMode.onMouseUp = DragCircleMode.onTouchEnd = function (state, e) {
+DragCircleMode.onMouseUp = DragCircleMode.onMouseMove = DragCircleMode.onTouchEnd = function (state, e) {
   dragPan.enable(this);
   return this.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [state.polygon.id] });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-draw-circle",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-draw-circle",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A module to draw a circle using mapbox-gl-draw",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
The functionality of "onMouseUp" will be broken if the mouse leaves the map's container area and is released