### PR TITLE
Improve supplementary points arrangement around large circles

### DIFF
--- a/lib/utils/create_supplementary_points_circle.js
+++ b/lib/utils/create_supplementary_points_circle.js
@@ -1,4 +1,6 @@
 const createVertex = require('@mapbox/mapbox-gl-draw/src/lib/create_vertex');
+const maxBy = require('lodash.maxby');
+const minBy = require('lodash.minby');
 
 function createSupplementaryPointsForCircle(geojson) {
   const { properties, geometry } = geojson;
@@ -7,9 +9,14 @@ function createSupplementaryPointsForCircle(geojson) {
 
   const supplementaryPoints = [];
   const vertices = geometry.coordinates[0].slice(0, -1);
-  for (let index = 0; index < vertices.length; index += Math.round((vertices.length / 4))) {
-    supplementaryPoints.push(createVertex(properties.id, vertices[index], `0.${index}`, false));
-  }
+  const northVertex = maxBy(vertices, (vertex) => vertex[0]);
+  const southVertex = minBy(vertices, (vertex) => vertex[0]);
+  const eastVertex = maxBy(vertices, (vertex) => vertex[1]);
+  const westVertex = minBy(vertices, (vertex) => vertex[1]);
+  supplementaryPoints.push(createVertex(properties.id, northVertex, `0.${vertices.indexOf(northVertex)}`, false));
+  supplementaryPoints.push(createVertex(properties.id, southVertex, `0.${vertices.indexOf(southVertex)}`, false));
+  supplementaryPoints.push(createVertex(properties.id, eastVertex, `0.${vertices.indexOf(eastVertex)}`, false));
+  supplementaryPoints.push(createVertex(properties.id, westVertex, `0.${vertices.indexOf(westVertex)}`, false));
   return supplementaryPoints;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-draw-circle",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3402,6 +3402,16 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.maxby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.maxby/-/lodash.maxby-4.6.0.tgz",
+      "integrity": "sha1-CCJABo88eiJ6oAqDgOTzjPB4bj0="
+    },
+    "lodash.minby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.minby/-/lodash.minby-4.6.0.tgz",
+      "integrity": "sha1-ixBXZa6XOVSulEqAKZmbgIC9+MQ="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "@turf/circle": "^6.0.1",
     "@turf/distance": "^6.0.1",
     "@turf/helpers": "^6.1.4",
-    "@turf/length": "^6.0.2"
+    "@turf/length": "^6.0.2",
+    "lodash.maxby": "^4.6.0",
+    "lodash.minby": "^4.6.0"
   },
   "devDependencies": {
     "jest": "^24.5.0"


### PR DESCRIPTION
Currently the supplementary points are not aligned well around large circles.

<img width="372" alt="Screenshot 2020-07-12 at 23 40 12" src="https://user-images.githubusercontent.com/173585/87257210-657db900-c499-11ea-9286-df88133c3aba.png">

This PR searches for the north/south/east/westmost points, and uses them as supplementary points.