### PR TITLE
Improve supplementary points arrangement around large circles

### DIFF
--- a/lib/utils/create_supplementary_points_circle.js
+++ b/lib/utils/create_supplementary_points_circle.js
@@ -1,5 +1,15 @@
 const createVertex = require('@mapbox/mapbox-gl-draw/src/lib/create_vertex');
 
+function minBy(arr, func) {
+  const min = Math.min(...arr.map(func));
+  return arr.find(item => func(item) === min);
+}
+
+function maxBy(arr, func) {
+  const max = Math.max(...arr.map(func));
+  return arr.find(item => func(item) === max);
+}
+
 function createSupplementaryPointsForCircle(geojson) {
   const { properties, geometry } = geojson;
 
@@ -7,9 +17,14 @@ function createSupplementaryPointsForCircle(geojson) {
 
   const supplementaryPoints = [];
   const vertices = geometry.coordinates[0].slice(0, -1);
-  for (let index = 0; index < vertices.length; index += Math.round((vertices.length / 4))) {
-    supplementaryPoints.push(createVertex(properties.id, vertices[index], `0.${index}`, false));
-  }
+  const northVertex = maxBy(vertices, (vertex) => vertex[0]);
+  const southVertex = minBy(vertices, (vertex) => vertex[0]);
+  const eastVertex = maxBy(vertices, (vertex) => vertex[1]);
+  const westVertex = minBy(vertices, (vertex) => vertex[1]);
+  supplementaryPoints.push(createVertex(properties.id, northVertex, `0.${vertices.indexOf(northVertex)}`, false));
+  supplementaryPoints.push(createVertex(properties.id, southVertex, `0.${vertices.indexOf(southVertex)}`, false));
+  supplementaryPoints.push(createVertex(properties.id, eastVertex, `0.${vertices.indexOf(eastVertex)}`, false));
+  supplementaryPoints.push(createVertex(properties.id, westVertex, `0.${vertices.indexOf(westVertex)}`, false));
   return supplementaryPoints;
 }
 


### PR DESCRIPTION
Currently the supplementary points are not aligned well around large circles.

<img width="372" alt="Screenshot 2020-07-12 at 23 40 12" src="https://user-images.githubusercontent.com/173585/87257210-657db900-c499-11ea-9286-df88133c3aba.png">

The changes involve finding the north/south/east/westmost points, and using them as supplementary points.

---

This PR is sponsored by [MariTrace](https://maritrace.com/)!