### PR TITLE
Update circle polygon when moving

### DIFF
--- a/__tests__/modes/DirectModeOverride.test.js
+++ b/__tests__/modes/DirectModeOverride.test.js
@@ -1,7 +1,7 @@
 
 jest.mock('@mapbox/mapbox-gl-draw/src/lib/create_supplementary_points');
 jest.mock('@mapbox/mapbox-gl-draw/src/lib/move_features');
-jest.mock('@mapbox/mapbox-gl-draw/src/lib/constrain_feature_movement');
+jest.mock('@mapbox/mapbox-gl-draw/src/lib/constrain_feature_movement', () => jest.fn((_, x) => x));
 jest.mock('@turf/distance', () => ({ default: jest.fn() }));
 jest.mock('@turf/helpers');
 jest.mock('@turf/circle', () => ({ default: jest.fn() }));
@@ -45,16 +45,15 @@ describe('DirectMode tests', () => {
         },
         geometry: {
           coordinates: []
-        }
+        },
+        incomingCoords: jest.fn(),
+        toGeoJSON: function() { return this; }
       }
     ];
     mockState = {
       featureId: 1,
-      feature: {
-        ...mockFeatures[0],
-        incomingCoords: jest.fn()
-      }
-    }
+      feature: mockFeatures[0]
+    };
     DirectMode.getSelected.mockReturnValue(mockFeatures);
   });
 
@@ -64,8 +63,10 @@ describe('DirectMode tests', () => {
   });
 
   it('should move selected features when dragFeature is invoked', () => {
+    circle.mockReturnValue(mockFeatures[0]);
     DirectMode.dragFeature(mockState, mockEvent, mockDelta);
-    expect(moveFeatures).toHaveBeenCalledWith(mockFeatures, mockDelta);
+    expect(mockState.feature.incomingCoords).toHaveBeenCalledWith(mockFeatures[0].geometry.coordinates);
+    expect(moveFeatures).toHaveBeenCalledWith([], mockDelta);
   });
 
   it('should update the center of the selected feature if its a circle', () => {

--- a/lib/modes/DirectModeOverride.js
+++ b/lib/modes/DirectModeOverride.js
@@ -1,6 +1,7 @@
 const MapboxDraw = require('@mapbox/mapbox-gl-draw');
 const createSupplementaryPoints = require('@mapbox/mapbox-gl-draw/src/lib/create_supplementary_points');
 const moveFeatures = require('@mapbox/mapbox-gl-draw/src/lib/move_features');
+const moveCircleFeatures = require('../utils/move_circle_features');
 const Constants = require('@mapbox/mapbox-gl-draw/src/constants');
 const constrainFeatureMovement = require('@mapbox/mapbox-gl-draw/src/lib/constrain_feature_movement');
 const distance = require('@turf/distance').default;
@@ -12,14 +13,10 @@ const createSupplementaryPointsForCircle = require('../utils/create_supplementar
 const DirectModeOverride = MapboxDraw.modes.direct_select;
 
 DirectModeOverride.dragFeature = function(state, e, delta) {
-  moveFeatures(this.getSelected(), delta);
-  this.getSelected()
-    .filter(feature => feature.properties.isCircle)
-    .map(circle => circle.properties.center)
-    .forEach(center => {
-      center[0] += delta.lng;
-      center[1] += delta.lat;
-    });
+  const features = this.getSelected().filter(feature => !feature.properties.isCircle);
+  const circleFeatures = this.getSelected().filter(feature => feature.properties.isCircle);
+  moveFeatures(features, delta);
+  moveCircleFeatures(circleFeatures, delta);
   state.dragMoveLocation = e.lngLat;
 };
 

--- a/lib/modes/SimpleSelectModeOverride.js
+++ b/lib/modes/SimpleSelectModeOverride.js
@@ -1,6 +1,7 @@
 const MapboxDraw = require('@mapbox/mapbox-gl-draw');
 const createSupplementaryPoints = require('@mapbox/mapbox-gl-draw/src/lib/create_supplementary_points');
 const moveFeatures = require('@mapbox/mapbox-gl-draw/src/lib/move_features');
+const moveCircleFeatures = require('../utils/move_circle_features');
 const Constants = require('@mapbox/mapbox-gl-draw/src/constants');
 const createSupplementaryPointsForCircle = require('../utils/create_supplementary_points_circle');
 
@@ -17,15 +18,10 @@ SimpleSelectModeOverride.dragMove = function(state, e) {
     lat: e.lngLat.lat - state.dragMoveLocation.lat
   };
 
-  moveFeatures(this.getSelected(), delta);
-
-  this.getSelected()
-    .filter(feature => feature.properties.isCircle)
-    .map(circle => circle.properties.center)
-    .forEach(center => {
-      center[0] += delta.lng;
-      center[1] += delta.lat;
-    });
+  const features = this.getSelected().filter(feature => !feature.properties.isCircle);
+  const circleFeatures = this.getSelected().filter(feature => feature.properties.isCircle);
+  moveFeatures(features, delta);
+  moveCircleFeatures(circleFeatures, delta);
 
   state.dragMoveLocation = e.lngLat;
 };

--- a/lib/utils/move_circle_features.js
+++ b/lib/utils/move_circle_features.js
@@ -1,0 +1,18 @@
+const constrainFeatureMovement = require('@mapbox/mapbox-gl-draw/src/lib/constrain_feature_movement');
+const circle = require('@turf/circle').default;
+
+function moveCircleFeatures(features, delta) {
+  const constrainedDelta = constrainFeatureMovement(features.map(feature => feature.toGeoJSON()), delta);
+
+  features.forEach((feature) => {
+    const center = feature.properties.center;
+    const radius = feature.properties.radiusInKm;
+    center[0] += constrainedDelta.lng;
+    center[1] += constrainedDelta.lat;
+    const circleFeature = circle(center, radius);
+
+    feature.incomingCoords(circleFeature.geometry.coordinates);
+  });
+}
+
+module.exports = moveCircleFeatures;


### PR DESCRIPTION
Currently moving the circle does not update the circle polygon vertices.

![unnamed](https://user-images.githubusercontent.com/173585/87356714-d76e0500-c562-11ea-945b-f2ab046a3cb5.jpg)

The changes involve calling `incomingCoords` with the updated circle polygon in `dragFeature`, and updating the tests.

---

Thanks to [MariTrace](https://maritrace.com/) for sponsoring this PR!