### PR TITLE
Pin @mapbox/mapbox-gl-draw to 1.1.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Anvesh Kumar Arrabochu",
   "license": "ISC",
   "dependencies": {
-    "@mapbox/mapbox-gl-draw": "^1.1.1",
+    "@mapbox/mapbox-gl-draw": "1.1.1",
     "@turf/along": "^6.0.1",
     "@turf/circle": "^6.0.1",
     "@turf/distance": "^6.0.1",


### PR DESCRIPTION
This prevents the `Cannot read property 'draw_polygon' of undefined` error

Fixes: #26 